### PR TITLE
Fixed namespaces in ViewModule.cs

### DIFF
--- a/Modules/HtmlDocument.cs
+++ b/Modules/HtmlDocument.cs
@@ -1,5 +1,4 @@
-﻿using MOD.Web.Element.Module;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Modules/ViewModule.cs
+++ b/Modules/ViewModule.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace MOD.Web.Element.Module
+namespace MOD.Web.Element.Modules
 {
 	public class ViewModule : IRenderable
 	{


### PR DESCRIPTION
I updated the namespace to match the folder structure. Not sure if the namespace difference was intentional or not. Feel free to close if this was intentional.
