### PR TITLE
AppVeyor Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# MOD.Web.Element
+# MOD.Web.Element [![Build status](https://ci.appveyor.com/api/projects/status/kgqdabt2ue4vm70x/branch/master?svg=true)](https://ci.appveyor.com/project/MarkitOnDemand/mod-web-element/branch/master)
 
 ![Element Logo](http://markitondemand.github.io/MOD.Web.Element/Content/img/logo.png)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,7 @@
+version: 1.0.{build}
+configuration: Release
+before_build:
+- nuget restore
+build:
+  project: MOD.Web.Element.sln
+  verbosity: minimal


### PR DESCRIPTION
This PR adds an appveyor.yml file and also a badge to display build status on AppVeyor.  I have also setup a Markit On Demand account along with MOD.Web.Element: https://ci.appveyor.com/project/MarkitOnDemand/mod-web-element  I believe anyone that is in the Owners GitHub group should have admin access on AppVeyor.  Let me know if that is not the case and I can fiddle with the settings.