### PR TITLE
Publish Nuget Package

### DIFF
--- a/MOD.Web.Element.nuspec
+++ b/MOD.Web.Element.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package >
+	<metadata>
+		<id>MOD.Web.Element</id>
+		<title>MOD.Web.Element</title>
+		<version>1.0.0</version>
+		<authors>Markit On Demand</authors>
+		<owners>Markit On Demand</owners>
+		<description>An Object Oriented, MVC-friendly approach to rendering HTML in C#.</description>
+		<licenseUrl>https://github.com/markitondemand/MOD.Web.Element#copyright-and-license</licenseUrl>
+		<projectUrl>https://github.com/markitondemand/MOD.Web.Element</projectUrl>
+		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<copyright>Copyright 2015</copyright>
+		<iconUrl>http://markitondemand.github.io/MOD.Web.Element/Content/img/logo.png</iconUrl>
+	</metadata>
+	<files>
+		<file src="bin\Release\*" target="lib\net35" />
+		<file src="bin\Release\*" target="lib\net45" />
+	</files>
+</package>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,12 +21,13 @@ nuget:
   disable_publish_on_pr: true
 
 deploy:
-	# Deploying to NuGet feed
+  # Deploying to NuGet feed
   - provider: NuGet
-  	# commenting out the below so that this goes to Nuget.org
+    # commenting out the below so that this goes to Nuget.org
     #server: https://my.nuget.server/feed
     api_key:
-      secure: foobar
+      # see https://ci.appveyor.com/tools/encrypt
+      secure: Y3tfv+WMI1ujvFWb8/r6Dl9OD+SgZRv/86BuTOaFHbX+7UBe42rvnejZcTjqI2fY
     # not sure about publishing symbols at this time...
     skip_symbols: true
     #symbol_server: https://your.symbol.server/feed

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,33 @@
+#
+# For more details, see http://www.appveyor.com/docs/appveyor-yml
+#
 version: 1.0.{build}
+# don't build on tags
+skip_tags: true
+# always build in Release mode
 configuration: Release
+# restore the nuget packages prior to attempting a build
 before_build:
 - nuget restore
 build:
   project: MOD.Web.Element.sln
   verbosity: minimal
+
+nuget:
+  account_feed: true
+  # disable the project feed since we will be sending the package to Nuget.org
+  project_feed: false
+  # do not publish a nuget package for pull requests
+  disable_publish_on_pr: true
+
+deploy:
+	# Deploying to NuGet feed
+  - provider: NuGet
+  	# commenting out the below so that this goes to Nuget.org
+    #server: https://my.nuget.server/feed
+    api_key:
+      secure: foobar
+    # not sure about publishing symbols at this time...
+    skip_symbols: true
+    #symbol_server: https://your.symbol.server/feed
+    artifact: MOD.Web.Element.nupkg


### PR DESCRIPTION
This update will start publishing a Nuget package for the Element library to Nuget.org.  Currently it is using my API Key to Nuget.org, but we can easily switch that out (including the project "Owner" on Nuget.org) at a later date.

Still need to do a little testing on my own account before we merge this in but wanted to get the PR out there.